### PR TITLE
Consider no auth token a loading state

### DIFF
--- a/components/ConvexClientProvider.tsx
+++ b/components/ConvexClientProvider.tsx
@@ -20,7 +20,7 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
 function useAuthFromAuthKit() {
   const { user, loading: isLoading } = useAuth();
   const { accessToken, loading: tokenLoading, error: tokenError } = useAccessToken();
-  const loading = (isLoading ?? false) || (tokenLoading ?? false);
+  const loading = (isLoading ?? false) || (tokenLoading ?? false) || !accessToken;
   const authenticated = !!user && !!accessToken && !loading;
 
   // Memoize the token to prevent unnecessary changes


### PR DESCRIPTION
An auth token not yet being available shoudl be considered a loading state for the [Convex useAuth helper](https://docs.convex.dev/auth/advanced/custom-auth#integrating-a-new-identity-provider)