### PR TITLE
Use subject since WorkOS AuthKit JWTs don't have a name property by default

### DIFF
--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -22,7 +22,7 @@ export const listNumbers = query({
       .order('desc')
       .take(args.count);
     return {
-      viewer: (await ctx.auth.getUserIdentity())?.name ?? null,
+      viewer: (await ctx.auth.getUserIdentity())?.subject ?? null,
       numbers: numbers.reverse().map((number) => number.value),
     };
   },


### PR DESCRIPTION
If developers don't customize their JWTs to have a name field then this will always be missing