### PR TITLE
Template suggestions

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,7 +3,3 @@ WORKOS_CLIENT_ID=client_your_client_id_here
 WORKOS_API_KEY=sk_test_your_api_key_here
 WORKOS_COOKIE_PASSWORD=your_secure_password_here_must_be_at_least_32_characters_long
 NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
-
-# Convex Configuration
-NEXT_PUBLIC_CONVEX_URL=https://your-convex-url.convex.cloud
-CONVEX_DEPLOY_KEY=your_convex_deploy_key_here

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ConvexClientProvider } from '@/components/ConvexClientProvider';
+import { withAuth } from '@workos-inc/authkit-nextjs';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -21,15 +22,16 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const expectAuth = !!(await withAuth()).user
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ConvexClientProvider>{children}</ConvexClientProvider>
+        <ConvexClientProvider expectAuth={expectAuth}>{children}</ConvexClientProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ConvexClientProvider } from '@/components/ConvexClientProvider';
-import { withAuth } from '@workos-inc/authkit-nextjs';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -22,16 +21,15 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const expectAuth = !!(await withAuth()).user
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ConvexClientProvider expectAuth={expectAuth}>{children}</ConvexClientProvider>
+        <ConvexClientProvider>{children}</ConvexClientProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,11 +50,7 @@ function Content() {
   const addNumber = useMutation(api.myFunctions.addNumber);
 
   if (viewer === undefined || numbers === undefined) {
-    return (
-      <div className="mx-auto">
-        <p>loading... (consider a loading skeleton)</p>
-      </div>
-    );
+    return <div className="mx-auto"></div>;
   }
 
   return (

--- a/app/server/inner.tsx
+++ b/app/server/inner.tsx
@@ -9,7 +9,7 @@ export default function Home({ preloaded }: { preloaded: Preloaded<typeof api.my
   return (
     <>
       <div className="flex flex-col gap-4 bg-slate-200 dark:bg-slate-800 p-4 rounded-md">
-        <h2 className="text-xl font-bold">Reactive client-loaded data</h2>
+        <h2 className="text-xl font-bold">Reactive client-loaded data (using server data during hydration)</h2>
         <code>
           <pre>{JSON.stringify(data, null, 2)}</pre>
         </code>

--- a/app/server/page.tsx
+++ b/app/server/page.tsx
@@ -1,11 +1,17 @@
 import Home from './inner';
 import { preloadQuery, preloadedQueryResult } from 'convex/nextjs';
 import { api } from '@/convex/_generated/api';
+import { withAuth } from '@workos-inc/authkit-nextjs';
 
 export default async function ServerPage() {
-  const preloaded = await preloadQuery(api.myFunctions.listNumbers, {
-    count: 3,
-  });
+  const { accessToken } = await withAuth();
+  const preloaded = await preloadQuery(
+    api.myFunctions.listNumbers,
+    {
+      count: 3,
+    },
+    { token: accessToken },
+  );
 
   const data = preloadedQueryResult(preloaded);
 

--- a/components/ConvexClientProvider.tsx
+++ b/components/ConvexClientProvider.tsx
@@ -5,9 +5,9 @@ import { ConvexReactClient } from 'convex/react';
 import { ConvexProviderWithAuth } from 'convex/react';
 import { AuthKitProvider, useAuth, useAccessToken } from '@workos-inc/authkit-nextjs/components';
 
-export function ConvexClientProvider({ children, expectAuth }: { children: ReactNode; expectAuth: boolean }) {
+export function ConvexClientProvider({ children }: { children: ReactNode }) {
   const [convex] = useState(() => {
-    return new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!, { expectAuth });
+    return new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
   });
   return (
     <AuthKitProvider>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@workos-inc/authkit-nextjs": "^2.4.4",
-    "convex": "^1.25.4",
+    "convex": "^1.26.2",
     "next": "15.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@workos-inc/authkit-nextjs": "^2.4.4",
+    "@workos-inc/authkit-nextjs": "^2.6.0",
     "convex": "^1.26.2",
     "next": "15.4.3",
     "react": "^19.0.0",


### PR DESCRIPTION
- Check auth on the server to know whether to wait for it on the client (instead of passing it in, both of these approaches discussed in https://github.com/workos/authkit-nextjs/issues/286#issuecomment-3235260068)
- Move ConvexClient to a provider to make above work
- Use an auth token for server components example to make it more realistic
- Change loading state machine based on suggestion in https://github.com/workos/template-convex-nextjs-authkit/issues/5#issuecomment-3217795306
- Remove CONVEX_DEPLOY_KEY from example .env.local file since it should almost never be used locally, see [docs](https://docs.convex.dev/cli/deploy-key-types)