### PR TITLE
Fix CORS errors on auth buttons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,12 +32,12 @@ function SignInForm() {
   return (
     <div className="flex flex-col gap-8 w-96 mx-auto">
       <p>Log in to see the numbers</p>
-      <Link href="/sign-in">
+      <a href="/sign-in">
         <button className="bg-foreground text-background px-4 py-2 rounded-md">Sign in</button>
-      </Link>
-      <Link href="/sign-up">
+      </a>
+      <a href="/sign-up">
         <button className="bg-foreground text-background px-4 py-2 rounded-md">Sign up</button>
-      </Link>
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
Quick fix for those annoying CORS errors that show up in console when clicking sign-in/sign-up buttons.

Swapped out Next.js Link components for regular anchor tags since these routes just do server redirects to WorkOS anyway. No need for client-side navigation here and it eliminates the prefetch issues.

Should be good to go!