### PR TITLE
Use expectAuth when not using `<Authenticated>` wrapper

### DIFF
--- a/app/(authed)/layout.tsx
+++ b/app/(authed)/layout.tsx
@@ -1,0 +1,5 @@
+import { ConvexClientProvider } from '@/components/ConvexClientProvider';
+
+export default async function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
+  return <ConvexClientProvider expectAuth>{children}</ConvexClientProvider>;
+}

--- a/app/(unauthed)/layout.tsx
+++ b/app/(unauthed)/layout.tsx
@@ -1,0 +1,5 @@
+import { ConvexClientProvider } from '@/components/ConvexClientProvider';
+
+export default function UnauthenticatedLayout({ children }: { children: React.ReactNode }) {
+  return <ConvexClientProvider>{children}</ConvexClientProvider>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { ConvexClientProvider } from '@/components/ConvexClientProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -28,9 +27,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ConvexClientProvider>{children}</ConvexClientProvider>
-      </body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
     </html>
   );
 }

--- a/components/ConvexClientProvider.tsx
+++ b/components/ConvexClientProvider.tsx
@@ -5,9 +5,9 @@ import { ConvexReactClient } from 'convex/react';
 import { ConvexProviderWithAuth } from 'convex/react';
 import { AuthKitProvider, useAuth, useAccessToken } from '@workos-inc/authkit-nextjs/components';
 
-export function ConvexClientProvider({ children }: { children: ReactNode }) {
+export function ConvexClientProvider({ children, expectAuth }: { children: ReactNode; expectAuth?: boolean }) {
   const [convex] = useState(() => {
-    return new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+    return new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!, { expectAuth });
   });
   return (
     <AuthKitProvider>


### PR DESCRIPTION
Testing with https://workos-convex-nextjs-testbed.previews.convex.dev/server-does-not-work ([code](https://github.com/get-convex/workos-convex-nextjs-testbed)) the current approach sometimes fails, particularly in prod.

We'd like to do something better here but for now this separate layouts appraoch seems necessary.