### PR TITLE
Don't require `aud` field for JWTs when issuer is unique

### DIFF
--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -14,7 +14,6 @@ const authConfig = {
       issuer: `https://api.workos.com/user_management/${clientId}`,
       algorithm: 'RS256',
       jwks: `https://api.workos.com/sso/jwks/${clientId}`,
-      applicationID: clientId,
     },
   ],
 };


### PR DESCRIPTION
similar to https://github.com/workos/template-convex-react-vite-authkit/pull/2